### PR TITLE
Module Root Fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function resolveBinding(name) {
       ? process._linkedBinding(name.replace(/\.node$/,''))
       : process.binding(name.replace(/\.node$/,''));
   }
-  return bindings({ bindings: name, module_root: bindings.getRoot(module.parent) });
+  return bindings({ bindings: name, module_root: bindings.getRoot(bindings.getFileName(__filename)) });
 }
 
 


### PR DESCRIPTION
module.parent.toString() === '[object Object]',
so dirname(module.parent) always returns '.'
This breaks when requiring a module that uses nad-bindings internally.
